### PR TITLE
Always authenticate with ECR when building + pushing images

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -46,12 +46,11 @@ jobs:
       # Configure AWS credentials
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
-        if: ${{ github.event_name == 'pull_request' }}
         with:
           role-to-assume: arn:aws:iam::580663733917:role/github-actions
           aws-region: us-east-1
+
       - name: Login to Amazon ECR
-        if: ${{ github.event_name == 'pull_request' }}
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v2
         with:


### PR DESCRIPTION
This ensures that we always authenticate with AWS when building + pushing container images to ECR.