### PR TITLE
Test with Go 1.24

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -14,7 +14,7 @@ jobs:
   build-go:
     strategy:
       matrix:
-        go-version: [1.21,1.22]
+        go-version: [1.24]
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/datagravity-ai/keel
 
-go 1.22.4
-
-toolchain go1.22.6
+go 1.24.0
 
 replace github.com/docker/distribution => github.com/docker/distribution v2.8.1+incompatible
 


### PR DESCRIPTION
Updates CI to use the current Go version.