### PR TITLE
Fix indentation in Docker build workflow

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -63,7 +63,7 @@ jobs:
         uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804 # v5.7.0
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-        tags: |
+          tags: |
             type=schedule
             type=ref,event=branch
             type=ref,event=pr


### PR DESCRIPTION
This fixes indentation in the Docker build workflow, which I broke in #355 