### PR TITLE
chore: update the jwt package to golang-jwt per migration.md

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -65,8 +65,8 @@ require (
 require (
 	cloud.google.com/go/storage v1.47.0
 	github.com/alecthomas/kingpin/v2 v2.4.0
-	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/distribution/distribution/v3 v3.0.0-20230722181636-7b502560cad4
+	github.com/golang-jwt/jwt v3.2.2+incompatible
 	github.com/golang-jwt/jwt/v4 v4.5.1
 	golang.org/x/oauth2 v0.27.0
 	helm.sh/helm/v3 v3.16.3

--- a/go.sum
+++ b/go.sum
@@ -135,8 +135,6 @@ github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8Yc
 github.com/denisenkom/go-mssqldb v0.0.0-20191124224453-732737034ffd/go.mod h1:xbL0rPBG9cCiLr28tMa8zpbdarY27NDyej4t/EjAShU=
 github.com/denisenkom/go-mssqldb v0.9.0 h1:RSohk2RsiZqLZ0zCjtfn3S4Gp4exhpBWHyQ7D0yGjAk=
 github.com/denisenkom/go-mssqldb v0.9.0/go.mod h1:xbL0rPBG9cCiLr28tMa8zpbdarY27NDyej4t/EjAShU=
-github.com/dgrijalva/jwt-go v3.2.0+incompatible h1:7qlOGliEKZXTDg6OTjfoBKDXWrumCAMpl/TFQ4/5kLM=
-github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/distribution/distribution/v3 v3.0.0-20230722181636-7b502560cad4 h1:DstcWc/NnRAc1hkOJm67dl4dgeQm/Gvl965lfZyOgRI=
 github.com/distribution/distribution/v3 v3.0.0-20230722181636-7b502560cad4/go.mod h1:+fqBJ4vPYo4Uu1ZE4d+bUtTLRXfdSL3NvCZIZ9GHv58=
 github.com/distribution/reference v0.6.0 h1:0IXCQ5g4/QMHHkarYzh5l+u8T3t73zM5QvfrDyIgxBk=
@@ -214,6 +212,8 @@ github.com/gobwas/glob v0.2.3/go.mod h1:d3Ez4x06l9bZtSvzIay5+Yzi0fmZzPgnTbPcKjJA
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
+github.com/golang-jwt/jwt v3.2.2+incompatible h1:IfV12K8xAKAnZqdXVzCZ+TOjboZ2keLg81eXfW3O+oY=
+github.com/golang-jwt/jwt v3.2.2+incompatible/go.mod h1:8pz2t5EyA70fFQQSrl6XZXzqecmYZeUEB8OUGHkxJ+I=
 github.com/golang-jwt/jwt/v4 v4.5.1 h1:JdqV9zKUdtaa9gdPlywC3aeoEsR681PlKC+4F5gQgeo=
 github.com/golang-jwt/jwt/v4 v4.5.1/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
 github.com/golang-sql/civil v0.0.0-20190719163853-cb61b32ac6fe h1:lXe2qZdvpiX5WZkZR4hgp4KJVfY3nMkvmwbVkpv1rVY=

--- a/pkg/http/auth.go
+++ b/pkg/http/auth.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 
 	"github.com/datagravity-ai/keel/pkg/auth"
-	request "github.com/dgrijalva/jwt-go/request"
+	request "github.com/golang-jwt/jwt/request"
 	log "github.com/sirupsen/logrus"
 )
 


### PR DESCRIPTION
https://github.com/dgrijalva/jwt-go?tab=readme-ov-file has been deprecated. We need to move to the golang-jwt package instead per the readme. I followed the migration guide to get us update to date and tested.

https://github.com/golang-jwt/jwt/blob/v3.2.1/MIGRATION_GUIDE.md