### PR TITLE
Add user 'anomalo' in Dockerfile to run as non-root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,9 @@ RUN apk --no-cache add ca-certificates
 VOLUME /data
 ENV XDG_DATA_HOME /data
 
+RUN addgroup -S anomalo && adduser -S anomalo -G anomalo
+
+USER anomalo
 COPY --from=0 /go/bin/keel /bin/keel
 ENTRYPOINT ["/bin/keel"]
 EXPOSE 9300


### PR DESCRIPTION
The updater ensures that we are always running the latest version of Anomalo available to our customers/installs.

We have no need to run as root, so this PR adds a user Anomalo and ensures we run as it.

This fixes a misconfiguration in the dockerfile for the updater/keel. and ensures customer scans come back clean