### PR TITLE
feat: retry Kubernetes resource updates on optimistic concurrency conflict

### DIFF
--- a/provider/kubernetes/implementer.go
+++ b/provider/kubernetes/implementer.go
@@ -22,6 +22,7 @@ import (
 type Implementer interface {
 	Namespaces() (*v1.NamespaceList, error)
 	Deployments(namespace string) (*apps_v1.DeploymentList, error)
+	Get(namespace, name, kind string) (*k8s.GenericResource, error)
 	Update(obj *k8s.GenericResource) error
 	Secret(namespace, name string) (*v1.Secret, error)
 	Pods(namespace, labelSelector string) (*v1.PodList, error)
@@ -119,16 +120,40 @@ func (i *KubernetesImplementer) Deployments(namespace string) (*apps_v1.Deployme
 	return l, err
 }
 
+// Get fetches a single resource by namespace, name, and kind from the API server
+func (i *KubernetesImplementer) Get(namespace, name, kind string) (*k8s.GenericResource, error) {
+	switch kind {
+	case "deployment":
+		obj, err := i.client.AppsV1().Deployments(namespace).Get(context.TODO(), name, meta_v1.GetOptions{})
+		if err != nil {
+			return nil, err
+		}
+		return k8s.NewGenericResource(obj)
+	case "statefulset":
+		obj, err := i.client.AppsV1().StatefulSets(namespace).Get(context.TODO(), name, meta_v1.GetOptions{})
+		if err != nil {
+			return nil, err
+		}
+		return k8s.NewGenericResource(obj)
+	case "daemonset":
+		obj, err := i.client.AppsV1().DaemonSets(namespace).Get(context.TODO(), name, meta_v1.GetOptions{})
+		if err != nil {
+			return nil, err
+		}
+		return k8s.NewGenericResource(obj)
+	case "cronjob":
+		obj, err := i.client.BatchV1().CronJobs(namespace).Get(context.TODO(), name, meta_v1.GetOptions{})
+		if err != nil {
+			return nil, err
+		}
+		return k8s.NewGenericResource(obj)
+	default:
+		return nil, fmt.Errorf("unsupported resource kind: %s", kind)
+	}
+}
+
 // Update converts generic resource into specific kubernetes type and updates it
 func (i *KubernetesImplementer) Update(obj *k8s.GenericResource) error {
-	// retryErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-	// 	// Retrieve the latest version of Deployment before attempting update
-	// 	// RetryOnConflict uses exponential backoff to avoid exhausting the apiserver
-	// 	_, updateErr := i.client.Extensions().Deployments(deployment.Namespace).Update(deployment)
-	// 	return updateErr
-	// })
-	// return retryErr
-
 	switch resource := obj.GetResource().(type) {
 	case *apps_v1.Deployment:
 		_, err := i.client.AppsV1().Deployments(resource.Namespace).Update(context.TODO(), resource, meta_v1.UpdateOptions{})

--- a/provider/kubernetes/kubernetes.go
+++ b/provider/kubernetes/kubernetes.go
@@ -379,7 +379,11 @@ func (p *Provider) updateDeployments(plans []*UpdatePlan) (updated []*k8s.Generi
 		// Capture the desired state so we can re-apply it on a fresh resource if
 		// the update hits an optimistic concurrency conflict (HTTP 409).
 		desiredImages := extractDesiredImages(resource)
-		desiredSpecAnnotations := resource.GetSpecAnnotations()
+		srcSpecAnnotations := resource.GetSpecAnnotations()
+		desiredSpecAnnotations := make(map[string]string, len(srcSpecAnnotations))
+		for k, v := range srcSpecAnnotations {
+			desiredSpecAnnotations[k] = v
+		}
 
 		firstAttempt := true
 		err = retry.RetryOnConflict(retry.DefaultRetry, func() error {

--- a/provider/kubernetes/kubernetes.go
+++ b/provider/kubernetes/kubernetes.go
@@ -22,6 +22,7 @@ import (
 	"github.com/datagravity-ai/keel/util/policies"
 
 	log "github.com/sirupsen/logrus"
+	"k8s.io/client-go/util/retry"
 )
 
 var kubernetesVersionedUpdatesCounter = prometheus.NewCounterVec(
@@ -370,11 +371,38 @@ func (p *Provider) updateDeployments(plans []*UpdatePlan) (updated []*k8s.Generi
 		var err error
 
 		timestamp := time.Now().Format(time.RFC3339)
-		annotations["kubernetes.io/change-cause"] = fmt.Sprintf("keel automated update, version %s -> %s [%s]", plan.CurrentVersion, plan.NewVersion, timestamp)
+		changeCause := fmt.Sprintf("keel automated update, version %s -> %s [%s]", plan.CurrentVersion, plan.NewVersion, timestamp)
+		annotations["kubernetes.io/change-cause"] = changeCause
 
 		resource.SetAnnotations(annotations)
 
-		err = p.implementer.Update(resource)
+		// Capture the desired state so we can re-apply it on a fresh resource if
+		// the update hits an optimistic concurrency conflict (HTTP 409).
+		desiredImages := extractDesiredImages(resource)
+		desiredSpecAnnotations := resource.GetSpecAnnotations()
+
+		firstAttempt := true
+		err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
+			if !firstAttempt {
+				fresh, getErr := p.implementer.Get(resource.Namespace, resource.Name, resource.Kind())
+				if getErr != nil {
+					return getErr
+				}
+				applyDesiredImages(fresh, desiredImages)
+				freshAnnotations := fresh.GetAnnotations()
+				freshAnnotations["kubernetes.io/change-cause"] = changeCause
+				fresh.SetAnnotations(freshAnnotations)
+				freshSpecAnnotations := fresh.GetSpecAnnotations()
+				for k, v := range desiredSpecAnnotations {
+					freshSpecAnnotations[k] = v
+				}
+				fresh.SetSpecAnnotations(freshSpecAnnotations)
+				resource = fresh
+				plan.Resource = fresh
+			}
+			firstAttempt = false
+			return p.implementer.Update(resource)
+		})
 		kubernetesVersionedUpdatesCounter.With(prometheus.Labels{"kubernetes": fmt.Sprintf("%s/%s", resource.Namespace, resource.Name)}).Inc()
 		if err != nil {
 			log.WithFields(log.Fields{
@@ -459,6 +487,46 @@ func (p *Provider) updateDeployments(plans []*UpdatePlan) (updated []*k8s.Generi
 	}
 
 	return
+}
+
+// desiredContainerImage records the target image for a container, identified by name.
+type desiredContainerImage struct {
+	Name  string
+	Image string
+	Init  bool
+}
+
+// extractDesiredImages captures the container names and images from an already-mutated resource.
+func extractDesiredImages(resource *k8s.GenericResource) []desiredContainerImage {
+	var desired []desiredContainerImage
+	for _, c := range resource.Containers() {
+		desired = append(desired, desiredContainerImage{Name: c.Name, Image: c.Image})
+	}
+	for _, c := range resource.InitContainers() {
+		desired = append(desired, desiredContainerImage{Name: c.Name, Image: c.Image, Init: true})
+	}
+	return desired
+}
+
+// applyDesiredImages applies the desired container images onto a resource, matching by container name.
+func applyDesiredImages(resource *k8s.GenericResource, desired []desiredContainerImage) {
+	for _, d := range desired {
+		if d.Init {
+			for idx, c := range resource.InitContainers() {
+				if c.Name == d.Name {
+					resource.UpdateInitContainer(idx, d.Image)
+					break
+				}
+			}
+		} else {
+			for idx, c := range resource.Containers() {
+				if c.Name == d.Name {
+					resource.UpdateContainer(idx, d.Image)
+					break
+				}
+			}
+		}
+	}
 }
 
 func getDesiredImage(delta map[string]string, currentImage string) (string, error) {

--- a/provider/kubernetes/kubernetes_test.go
+++ b/provider/kubernetes/kubernetes_test.go
@@ -1,6 +1,7 @@
 package kubernetes
 
 import (
+	"fmt"
 	"log"
 	"os"
 	"path/filepath"
@@ -14,7 +15,9 @@ import (
 
 	apps_v1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	core_v1 "k8s.io/client-go/kubernetes/typed/core/v1"
 )
 
@@ -95,6 +98,13 @@ func (i *fakeImplementer) DeletePod(namespace, name string, opts *meta_v1.Delete
 
 func (i *fakeImplementer) ConfigMaps(namespace string) core_v1.ConfigMapInterface {
 	return nil
+}
+
+func (i *fakeImplementer) Get(namespace, name, kind string) (*k8s.GenericResource, error) {
+	if i.deployment != nil {
+		return k8s.NewGenericResource(i.deployment.DeepCopy())
+	}
+	return nil, fmt.Errorf("resource not found")
 }
 
 type fakeSender struct {
@@ -1644,6 +1654,114 @@ func TestTrackedImagesWithSecrets(t *testing.T) {
 	}
 	if imgs[0].Secrets[1] != "very-secret" {
 		t.Errorf("expected very-secret, got: %s", imgs[0].Secrets[1])
+	}
+}
+
+// conflictFakeImplementer simulates a 409 conflict on the first Update call.
+type conflictFakeImplementer struct {
+	fakeImplementer
+	updateCallCount int
+	// latestDeployment is what Get returns (simulates the current cluster state)
+	latestDeployment *apps_v1.Deployment
+}
+
+func (i *conflictFakeImplementer) Update(obj *k8s.GenericResource) error {
+	i.updateCallCount++
+	if i.updateCallCount == 1 {
+		return apierrors.NewConflict(
+			schema.GroupResource{Group: "apps", Resource: "deployments"},
+			obj.Name,
+			fmt.Errorf("the object has been modified"),
+		)
+	}
+	i.updated = obj
+	return nil
+}
+
+func (i *conflictFakeImplementer) Get(namespace, name, kind string) (*k8s.GenericResource, error) {
+	if i.latestDeployment != nil {
+		return k8s.NewGenericResource(i.latestDeployment.DeepCopy())
+	}
+	return i.fakeImplementer.Get(namespace, name, kind)
+}
+
+func TestProcessEvent_RetryOnConflict(t *testing.T) {
+	fp := &conflictFakeImplementer{}
+	fp.namespaces = &v1.NamespaceList{
+		Items: []v1.Namespace{
+			{
+				meta_v1.TypeMeta{},
+				meta_v1.ObjectMeta{Name: "ns-1"},
+				v1.NamespaceSpec{},
+				v1.NamespaceStatus{},
+			},
+		},
+	}
+
+	dep := &apps_v1.Deployment{
+		meta_v1.TypeMeta{},
+		meta_v1.ObjectMeta{
+			Name:            "deployment-1",
+			Namespace:       "ns-1",
+			Labels:          map[string]string{types.KeelPolicyLabel: "all"},
+			Annotations:     map[string]string{},
+			ResourceVersion: "1000",
+		},
+		apps_v1.DeploymentSpec{
+			Template: v1.PodTemplateSpec{
+				ObjectMeta: meta_v1.ObjectMeta{
+					Annotations: map[string]string{},
+				},
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{
+							Name:  "main",
+							Image: "gcr.io/v2-namespace/hello-world:1.1.1",
+						},
+					},
+				},
+			},
+		},
+		apps_v1.DeploymentStatus{},
+	}
+
+	// latestDeployment simulates what the API server returns on re-fetch —
+	// same deployment but with a bumped resourceVersion (as if another controller modified it).
+	latestDep := dep.DeepCopy()
+	latestDep.ResourceVersion = "1001"
+	fp.latestDeployment = latestDep
+
+	grs := MustParseGRS([]*apps_v1.Deployment{dep})
+	grc := &k8s.GenericResourceCache{}
+	grc.Add(grs...)
+	approver, teardown := approver()
+	defer teardown()
+	provider, err := NewProvider(fp, &fakeSender{}, approver, grc)
+	if err != nil {
+		t.Fatalf("failed to get provider: %s", err)
+	}
+
+	repo := types.Repository{
+		Name: "gcr.io/v2-namespace/hello-world",
+		Tag:  "1.4.5",
+	}
+
+	event := &types.Event{Repository: repo}
+	_, err = provider.processEvent(event)
+	if err != nil {
+		t.Fatalf("got error while processing event: %s", err)
+	}
+
+	if fp.updateCallCount != 2 {
+		t.Errorf("expected 2 Update calls (1 conflict + 1 success), got: %d", fp.updateCallCount)
+	}
+
+	if fp.updated == nil {
+		t.Fatalf("resource was not updated")
+	}
+
+	if fp.updated.Containers()[0].Image != repo.Name+":"+repo.Tag {
+		t.Errorf("expected image %s:%s but got: %s", repo.Name, repo.Tag, fp.updated.Containers()[0].Image)
 	}
 }
 

--- a/util/testing/testing.go
+++ b/util/testing/testing.go
@@ -36,6 +36,14 @@ func (i *FakeK8sImplementer) Namespaces() (*v1.NamespaceList, error) {
 	return i.NamespacesList, nil
 }
 
+// Get - get a single resource by namespace, name, and kind
+func (i *FakeK8sImplementer) Get(namespace, name, kind string) (*k8s.GenericResource, error) {
+	if i.DeploymentSingle != nil {
+		return k8s.NewGenericResource(i.DeploymentSingle.DeepCopy())
+	}
+	return nil, fmt.Errorf("resource not found")
+}
+
 // Deployment - available deployment, doesn't filter anything
 func (i *FakeK8sImplementer) Deployment(namespace, name string) (*apps_v1.Deployment, error) {
 	return i.DeploymentSingle, nil


### PR DESCRIPTION
## Summary

- Adds `retry.RetryOnConflict` around Kubernetes resource updates so that 409 "object has been modified" errors are retried instead of silently failing
- Adds `Get(namespace, name, kind)` to the `Implementer` interface to support re-fetching the latest resource version from the API server on conflict
- On retry, re-applies desired image mutations (matched by container name) and merges annotations onto the fresh resource

## Context

When another controller (HPA, another operator, duplicate webhooks) modifies a deployment between when Keel caches it and when it calls `Update()`, the Kubernetes API returns a 409 conflict. There was commented-out `RetryOnConflict` code in `implementer.go` that was never functional. This is a known upstream issue ([keel-hq/keel#242](https://github.com/keel-hq/keel/issues/242)) that was never fixed.

## Test plan

- [x] New `TestProcessEvent_RetryOnConflict` test verifies the retry path: first `Update` returns a 409 conflict, `Get` re-fetches a fresh resource, second `Update` succeeds with the correct image
- [x] All existing unit tests pass (`go test ./provider/kubernetes/... ./bot/... ./util/...`)
- [x] `go build ./...` compiles cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)