### PR TITLE
feat(gha): use private ECR registry; build PRs

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -17,10 +17,8 @@ on:
 
 env:
   # Use docker.io for Docker Hub if empty
-  REGISTRY: public.ecr.aws
-  # github.repository as <account>/<repo>
-  IMAGE_NAME: anomalo/tools/keel
-
+  REGISTRY: ${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.us-west-2.amazonaws.com/tools-ci
+  IMAGE_NAME: keel
 
 jobs:
   build:
@@ -57,13 +55,11 @@ jobs:
         uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ secrets.GHA_AWS_ROLE_ARN }}
-          aws-region: us-east-1
+          aws-region: us-west-2
 
       - name: Login to Amazon ECR
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v2
-        with:
-          registry-type: public
 
       # Extract metadata (tags, labels) for Docker
       # https://github.com/docker/metadata-action
@@ -88,19 +84,17 @@ jobs:
           context: .
           platforms: ${{ matrix.platform }}
           labels: ${{ steps.meta.outputs.labels }}
-          outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=${{ github.event_name != 'pull_request' }}
+          outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
           cache-from: type=gha,scope=${{ steps.platform.outputs.name }}
           cache-to: type=gha,mode=max,scope=${{ steps.platform.outputs.name }}
 
       - name: Export digest
-        if: github.event_name != 'pull_request'
         run: |
           mkdir -p /tmp/digests
           digest="${{ steps.build.outputs.digest }}"
           touch "/tmp/digests/${digest#sha256:}"
 
       - name: Upload digest
-        if: github.event_name != 'pull_request'
         uses: actions/upload-artifact@v7
         with:
           name: digests-${{ steps.platform.outputs.name }}
@@ -111,7 +105,6 @@ jobs:
   merge:
     runs-on: ubuntu-latest
     needs: [build]
-    if: github.event_name != 'pull_request'
     permissions:
       contents: read
       packages: write
@@ -132,13 +125,11 @@ jobs:
         uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ secrets.GHA_AWS_ROLE_ARN }}
-          aws-region: us-east-1
+          aws-region: us-west-2
 
       - name: Login to Amazon ECR
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v2
-        with:
-          registry-type: public
 
       # Extract metadata (tags, labels) for Docker
       # https://github.com/docker/metadata-action


### PR DESCRIPTION
- Use a private ECR registry for docker images. Public ECR doesn't support lifecycle policies, so this allows us to easily prune old images
- Push docker images on PRs so we can test them in-cluster